### PR TITLE
cmake: fix output directory hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,9 @@ list(REMOVE_DUPLICATES DIRS)
 foreach(DIR ${DIRS})
   file(GLOB SRC ${DIR}/*.cc)
   add_executable(${DIR} ${SRC})
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${DIR}) #needed for out-of-source build
   target_link_libraries(${DIR} ${VOTCA_CSG_LIBRARIES} ${VOTCA_TOOLS_LIBRARIES} ${BOOST_LIBRARIES})
   install(TARGETS ${DIR} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-  set_target_properties(${DIR} PROPERTIES OUTPUT_NAME ${DIR}/csg_${DIR})
+  set_target_properties(${DIR} PROPERTIES OUTPUT_NAME csg_${DIR} RUNTIME_OUTPUT_DIRECTORY ${DIR})
   if(ENABLE_TESTING)
     add_test(${DIR}Help ${DIR}/csg_${DIR} --help)
     # run tests for tools and csg as well for coverage


### PR DESCRIPTION
Hope that helps against this rpmlint error:
```
ERROR   0002: file '/usr/bin/csg_traj_force' contains an invalid rpath '/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/csg/src/libcsg' in [/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/csg/src/libcsg:/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/tools/src/libtools:]
ERROR   0002: file '/usr/bin/csg_traj_force' contains an invalid rpath '/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/tools/src/libtools' in [/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/csg/src/libcsg:/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/tools/src/libtools:]
ERROR   0010: file '/usr/bin/csg_traj_force' contains an empty rpath in [/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/csg/src/libcsg:/home/junghans/rpmbuild/BUILD/votca-1.5/x86_64-redhat-linux-gnu/tools/src/libtools:]
```