### PR TITLE
.gitlab-ci.yml: allow rawhide builds to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,7 @@ Debug GCC Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Debug Clang Rawhide:
   variables:
@@ -137,6 +138,7 @@ Debug Clang Rawhide:
     CMAKE_BUILD_TYPE: "Debug"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Rawhide:
   variables:
@@ -145,6 +147,7 @@ Release GCC Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release Clang Rawhide:
   variables:
@@ -153,6 +156,7 @@ Release Clang Rawhide:
     CMAKE_BUILD_TYPE: "Release"
     DISTRO: "fedora_rawhide"
   extends: .build
+  allow_failure: true
 
 Release GCC Module:
   variables:


### PR DESCRIPTION
Part of https://github.com/votca/votca/pull/159

Workaround for https://github.com/openucx/ucx/issues/3558